### PR TITLE
Add readHyperSpyH5 to downloads section

### DIFF
--- a/download.rst
+++ b/download.rst
@@ -48,7 +48,9 @@ ImportRPL Digital Micrograph plugin
 
 Lastest version release date: 24/05/2012. Minor bugs were solved and new features added.
 
-This Digital Micrograph plugin is designed to import Ripple files into Digital Micrograph. It is used to easy data transit between DigitalMicrograph and HyperSpy without losing the calibration using the extra keywords that HyperSpy adds to the standard format.
+This Digital Micrograph plugin is designed to import Ripple files into Digital Micrograph. 
+It is used to ease data transit between DigitalMicrograph and HyperSpy without losing 
+the calibration using the extra keywords that HyperSpy adds to the standard format.
 
 When executed it will ask for 2 files:
 

--- a/download.rst
+++ b/download.rst
@@ -70,19 +70,8 @@ ImportRPL was written by Luiz Fernando Zagonel.
 readHyperSpyH5 MATLAB Plugin
 ---------------------------
 
-Initial release date: 18/04/2017. 
-
-This MATLAB script is designed to import HyperSpy's saved .hdf5 files. 
+This MATLAB script is designed to import HyperSpy's saved HDF5 files (``.hspy`` extension). 
 Like the Digital Micrograph script above, it is used to easily transfer data
-between MATLAB and HyperSpy without losing the axial calibration information.
-The underlying data is returned as the primary output, and axis metadata 
-(such as names, units, scales, etc.) are returned as supplemental output.
+from HyperSpy to MATLAB, while retaining spatial calibration information.
 
-The script has been tested on 2D and 3D hyperspectral data (spectrum images),
-but should work for arbitrarily sized data. Please raise an issue on 
-`Github <https://github.com/hyperspy/hyperspy/issues>`_ or in the 
-`Gitter chat <https://gitter.im/hyperspy/hyperspy>`_ with any issues.
-
-readHyperSpyH5 was written by `Joshua Taillon <https://www.nist.gov/people/joshua-taillon>`_.
-
-`Download readHyperSpyH5 <https://github.com/downloads/hyperspy/readHyperSpyH5/readHyperSpyH5.m>`_
+Download ``readHyperSpyH5`` from its `Github repository <https://github.com/jat255/readHyperSpyH5>`_.

--- a/download.rst
+++ b/download.rst
@@ -62,3 +62,25 @@ ImportRPL was written by Luiz Fernando Zagonel.
 
 
 `Download ImportRPL <https://github.com/downloads/hyperspy/ImportRPL/ImportRPL.s>`_
+
+.. _hyperspy-matlab:
+
+readHyperSpyH5 MATLAB Plugin
+---------------------------
+
+Initial release date: 18/04/2017. 
+
+This MATLAB script is designed to import HyperSpy's saved .hdf5 files. 
+Like the Digital Micrograph script above, it is used to easily transfer data
+between MATLAB and HyperSpy without losing the axial calibration information.
+The underlying data is returned as the primary output, and axis metadata 
+(such as names, units, scales, etc.) are returned as supplemental output.
+
+The script has been tested on 2D and 3D hyperspectral data (spectrum images),
+but should work for arbitrarily sized data. Please raise an issue on 
+`Github <https://github.com/hyperspy/hyperspy/issues>`_ or in the 
+`Gitter chat <https://gitter.im/hyperspy/hyperspy>`_ with any issues.
+
+readHyperSpyH5 was written by `Joshua Taillon <https://www.nist.gov/people/joshua-taillon>`_.
+
+`Download readHyperSpyH5 <https://github.com/downloads/hyperspy/readHyperSpyH5/readHyperSpyH5.m>`_


### PR DESCRIPTION
Currently, the link requires adding the matlab script as a repository in the account of the "hyperspy" Github user.