### PR TITLE
Add HyperSpyUI link to navigation bar

### DIFF
--- a/_templates/navbar.html
+++ b/_templates/navbar.html
@@ -1,9 +1,11 @@
 <a href="{{pathto('index')}}">Home</a> ·
 <a target="_blank"
-   href="http://hyperspy.org/hyperspy-doc/current/user_guide/install.html">Download</a> ·
+   href="https://hyperspy.org/hyperspy-doc/current/user_guide/install.html">Download</a> ·
+<a target="_blank"
+   href="https://hyperspy.org/hyperspyUI/">HyperSpyUI</a> ·
 <a href="{{pathto('documentation')}}">Documentation</a> ·
 <a target="_blank" href="https://github.com/hyperspy/hyperspy-demos">Demos</a> ·
 <a href="{{pathto('news')}}">News</a> ·
 <a href="{{pathto('support')}}">Support</a> ·
-<a target="_blank" href="http://hyperspy.org/hyperspy-doc/current/citing.html">Citing</a> ·
+<a target="_blank" href="https://hyperspy.org/hyperspy-doc/current/citing.html">Citing</a> ·
 <a target="_blank" href="https://github.com/hyperspy/hyperspy/graphs/contributors">Credits</a>


### PR DESCRIPTION
Closes https://github.com/hyperspy/hyperspy/issues/1869. There is actually no links to hyperspyui on the website.