### PR TITLE
Update workflow to push built website to separate repository

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,9 +14,14 @@ jobs:
 
   Push:
     needs: Build
-    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'ericpre' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'hyperspy' }}
     permissions:
       # needs write permission to push the docs to gh-pages
       contents: write
     # Use the "reusable workflow" from the hyperspy organisation
     uses: hyperspy/.github/.github/workflows/push_doc.yml@main
+    with:
+      repository: 'hyperspy/hyperspy.github.com'
+      branch: 'main'
+    secrets:
+      access_token: ${{ secrets.PAT }}


### PR DESCRIPTION
See https://github.com/ad-m/github-push-action/tree/master?tab=readme-ov-file#inputs - I have setup the access token accordingly and it should push to the hyperspy/hyperspy.github.com repository when merged.
