### PR TITLE
Add categories to ablog

### DIFF
--- a/news/ACMM2020.rst
+++ b/news/ACMM2020.rst
@@ -1,7 +1,6 @@
-
-
 .. post:: 2019-10-01
    :tags: training
+   :category: event
 
 HyperSpy Workshop at ACMM 2020
 ==============================

--- a/news/CCEM2020.rst
+++ b/news/CCEM2020.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2020-03-01
    :tags: training, videos
+   :category: event
 
 HyperSpy Lectures @ CCEM Workshop
 =================================

--- a/news/CLEBIC2023.rst
+++ b/news/CLEBIC2023.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2023-01-01
-   :tags: training
+   :tags: training, lumiSpy
+   :category: event
 
 HyperSpy/LumiSpy Tutorial @ CLEBIC, March 22-24, 2023
 =====================================================

--- a/news/CSBMM2021.rst
+++ b/news/CSBMM2021.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2021-05-01
    :tags: training
+   :category: event
 
 HyperSpy Workshop @ CSBMM 2021
 ==============================

--- a/news/Delft2018.rst
+++ b/news/Delft2018.rst
@@ -1,7 +1,6 @@
-
-
 .. post:: 2018-10-01
    :tags: training
+   :category: event
 
 HyperSpy Workshop at TU Delft
 =============================

--- a/news/EMAG2021.rst
+++ b/news/EMAG2021.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2021-04-01
    :tags: training
+   :category: event
 
 HyperSpy Workshop @ MMC/EMAG 2021
 =================================

--- a/news/EMC2016.rst
+++ b/news/EMC2016.rst
@@ -1,7 +1,6 @@
-
-
 .. post:: 2016-05-6
    :tags: training, EMC
+   :category: event
 
 HyperSpy workshop at EMC2016
 ============================

--- a/news/EMC2024.rst
+++ b/news/EMC2024.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2024-01-06
    :tags: training, EMC
+   :category: event
 
 HyperSpy Workshop @ EMC2024, 25th of August 2024
 ================================================

--- a/news/IMC2014.rst
+++ b/news/IMC2014.rst
@@ -1,5 +1,6 @@
 .. post:: 2014-04-1
    :tags: training
+   :category: event
 
 HyperSpy training at the IMC2014
 ================================

--- a/news/IUMAS2023.rst
+++ b/news/IUMAS2023.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2023-03-01
-   :tags: training
+   :tags: training, lumiSpy, pyxem, kikuchipy
+   :category: event
 
 Open Source Data Analysis Workshop @ IUMAS-8, June 12, 2023
 ===========================================================

--- a/news/M&M2019.rst
+++ b/news/M&M2019.rst
@@ -1,7 +1,6 @@
-
-
 .. post:: 2019-03-01
    :tags: training, M&M
+   :category: event
 
 HyperSpy Workshop at M&M 2019
 =============================

--- a/news/M&M2021.rst
+++ b/news/M&M2021.rst
@@ -1,7 +1,6 @@
-
-
 .. post:: 2021-03-01
    :tags: training, M&M
+   :category: event
 
 HyperSpy Workshop at M&M 2021
 =============================

--- a/news/M&M2022.rst
+++ b/news/M&M2022.rst
@@ -1,7 +1,6 @@
-
-
 .. post:: 2022-03-01
    :tags: training, M&M
+   :category: event
 
 HyperSpy Workshop at M&M 2022
 =============================

--- a/news/NTNU2024.rst
+++ b/news/NTNU2024.rst
@@ -1,5 +1,6 @@
 .. post:: 2024-01-12
    :tags: training
+   :category: event
 
 Analysis of 4D-STEM DATA @ NTNU, 11-13th of June 2024
 =====================================================

--- a/news/SCANDEM2016.rst
+++ b/news/SCANDEM2016.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2016-03-18
    :tags: training
+   :category: event
 
 HyperSpy workshop at SCANDEM2016
 ================================

--- a/news/SFmu2023.rst
+++ b/news/SFmu2023.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2023-03-01
-   :tags: training
+   :tags: training, SFµ, lumiSpy, pyxem
+   :category: event
 
 HyperSpy Training Workshop @ 18e colloque SFµ, July 3-4, 2023
 =============================================================

--- a/news/cambridge2015.rst
+++ b/news/cambridge2015.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2015-03-18
    :tags: training
+   :category: event
 
 HyperSpy Workshop @ Cambridge (UK), 13th of April 2015
 ======================================================

--- a/news/doi.rst
+++ b/news/doi.rst
@@ -1,4 +1,6 @@
 .. post:: 2015-04-15
+   :tags: doi
+   :category: news
 
 Citing HyperSpy
 ===============

--- a/news/eBEAM2024.rst
+++ b/news/eBEAM2024.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2024-01-11
-   :tags: training
+   :tags: training, summer-school, lumiSpy, eXSpy
+   :category: event
 
 HyperSpy lecture and tutorial @ eBEAM summer school, Sept. 1-13, 2024
 =====================================================================

--- a/news/ePSIC2018.rst
+++ b/news/ePSIC2018.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2018-02-01
    :tags: training, diamond
+   :category: event
 
 HyperSpy Workshop @ Diamond, 26-27th of March 2018
 ==================================================

--- a/news/ePSIC2019.rst
+++ b/news/ePSIC2019.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2019-02-01
    :tags: training, diamond
+   :category: event
 
 HyperSpy Workshop @ Diamond, 14-15th of March 2019
 ==================================================

--- a/news/ePSIC2020.rst
+++ b/news/ePSIC2020.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2020-02-01
    :tags: training, diamond
+   :category: event
 
 HyperSpy Workshop @ Diamond, 2nd-3rd of April 2020
 ==================================================

--- a/news/ePSIC2021.rst
+++ b/news/ePSIC2021.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2021-02-01
    :tags: training, diamond
+   :category: event
 
 HyperSpy Workshop @ Diamond, 19-24th of April 2021
 ==================================================

--- a/news/ePSIC2022.rst
+++ b/news/ePSIC2022.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2022-01-05
    :tags: training, diamond
+   :category: event
 
 HyperSpy Workshop @ Diamond, 9-13th of May 2022
 ===============================================

--- a/news/ePSIC2023.rst
+++ b/news/ePSIC2023.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2023-02-01
    :tags: training, diamond
+   :category: event
 
 HyperSpy Workshop @ Diamond, 22-26th of May 2023
 ================================================

--- a/news/interactive_demos.rst
+++ b/news/interactive_demos.rst
@@ -1,6 +1,6 @@
-
-
 .. post:: 2018-02-28
+   :tags: demos
+   :category: news
 
 New interactive demos
 =====================

--- a/news/new_demos_scandem.rst
+++ b/news/new_demos_scandem.rst
@@ -1,5 +1,6 @@
-
 .. post:: 2016-06-17
+   :tags: demos
+   :category: news
 
 New demos added
 ===============

--- a/news/new_demos_section.rst
+++ b/news/new_demos_section.rst
@@ -1,12 +1,13 @@
-
 .. post:: 2014-06-19
+   :tags: demos
+   :category: news
 
-New demos section
-=================
+New demos repository
+====================
 
 The examples section in the HyperSpy website has been replaced by a new `demos
 <https://nbviewer.jupyter.org/github/hyperspy/hyperspy-demos/tree/main/>`_
-section.
+repository.
 
 The demos are
 in the form of IPython notebooks and contain examples of usage. They can be

--- a/news/release_importrpl.rst
+++ b/news/release_importrpl.rst
@@ -1,4 +1,6 @@
 .. post:: 2012-02-29
+   :tags: plugins
+   :category: news
 
 New release of ImportRPL
 ========================

--- a/news/scipy2016_talk.rst
+++ b/news/scipy2016_talk.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2016-7-15
    :tags: videos
+   :category: news
 
 Scipy2016 HyperSpy talk
 =======================

--- a/news/sfmu2013.rst
+++ b/news/sfmu2013.rst
@@ -1,9 +1,9 @@
-
 .. post:: 2013-06-04
    :tags: training
+   :category: event
 
-HyperSpy tutorial at the SFmu2013
+HyperSpy tutorial at the SFµ 2013
 =================================
 
 A tutorial on analysis of multidimensional spectra using HyperSpy is 
-available as part of the official program of SFMu 2013.
+available as part of the official program of SFµ 2013.

--- a/news/shire2014.rst
+++ b/news/shire2014.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2014-04-1
    :tags: training
+   :category: event
 
 HyperSpy talks and training at SHIRE2014
 ========================================

--- a/news/superstem2014.rst
+++ b/news/superstem2014.rst
@@ -1,6 +1,6 @@
-
 .. post:: 2014-06-18
-   :tags: training
+   :tags: training, summer-school
+   :category: event
 
 HyperSpy practical at the SuperSTEM Summer School
 =================================================

--- a/news/superstem2018.rst
+++ b/news/superstem2018.rst
@@ -1,5 +1,6 @@
-
 .. post:: 2018-06-18
+   :tags: training, summer-school
+   :category: event
 
 HyperSpy practical at the SuperSTEM Summer School
 =================================================


### PR DESCRIPTION
Define categories `news` and `event` in ablog posts to allow separate listing in the future (`blog-post` or `release` could be other categories for the future).
Add some tags.