### PR TITLE
Update Gitter link

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -68,7 +68,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "Gitter",
-            "url": "https://gitter.im/hyperspy",
+            "url": "https://gitter.im/hyperspy/hyperspy",
             "icon": "fab fa-gitter",
         },
     ],


### PR DESCRIPTION
The gitter link in the header appears to be broken.  This should update it to the new link.