### PR TITLE
Update displayed news in landing page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,6 +28,10 @@ extensions = [
     'selective_css',
 ]
 
+linkcheck_ignore = [
+    "https://sbmm.org.br/en/28o-csbmm",  # 403 Client Error: Forbidden for url
+]
+
 # sitemap settings
 html_baseurl = environ.get("SPHINX_HTML_BASE_URL", "https://hyperspy.org")
 sitemap_locales = [None]

--- a/index.rst
+++ b/index.rst
@@ -104,9 +104,10 @@
 
    Latest News
 
-.. postlist:: 3
+.. postlist::
    :list-style: circle
    :format: {title}
+   :tags: upcoming
 
 
 .. _ecosystem_label:

--- a/news/EMC2024.rst
+++ b/news/EMC2024.rst
@@ -1,5 +1,5 @@
 .. post:: 2024-01-06
-   :tags: training, EMC
+   :tags: training, EMC, upcoming
    :category: event
 
 HyperSpy Workshop @ EMC2024, 25th of August 2024

--- a/news/NTNU2024.rst
+++ b/news/NTNU2024.rst
@@ -1,5 +1,5 @@
 .. post:: 2024-01-12
-   :tags: training
+   :tags: training, upcoming
    :category: event
 
 Analysis of 4D-STEM DATA @ NTNU, 11-13th of June 2024

--- a/news/eBEAM2024.rst
+++ b/news/eBEAM2024.rst
@@ -1,5 +1,5 @@
 .. post:: 2024-01-11
-   :tags: training, summer-school, lumiSpy, eXSpy
+   :tags: training, summer-school, lumiSpy, eXSpy, upcoming
    :category: event
 
 HyperSpy lecture and tutorial @ eBEAM summer school, Sept. 1-13, 2024

--- a/news/ePSIC2024.rst
+++ b/news/ePSIC2024.rst
@@ -7,11 +7,11 @@ HyperSpy Workshop @ Diamond, 13-17th of May 2024
 
 We are happy to announce the HyperSpy workshop @ Diamond will take place online the 13-17th of May 2024.
 
-More information and registration `on the Diamond website <https://www.diamond.ac.uk/Home/Events/2024/HyperSpy-Workshop-2024.html>`_.
+Registration on the `Diamond website <https://www.diamond.ac.uk/Home/Events/2024/HyperSpy-Workshop-2024.html>`_
 
-The teaching material will be available closer to the event.
+More information and teaching materials on the `ePSIC documentation website <https://diamondlightsource.atlassian.net/wiki/spaces/EPSICWEB/pages/1088061441/Hyperspy+Workshop-+2024>`_.
 
 .. image:: https://www.diamond.ac.uk/.resources/DiamondLightModule/webresources/img/Diamond-logo-colour.png
     :alt: Diamond logo
     :width: 200
-    :target: https://www.diamond.ac.uk/Home/Events/2024/HyperSpy-Workshop-2024.html
+    :target: https://diamondlightsource.atlassian.net/wiki/spaces/EPSICWEB/pages/1088061441/Hyperspy+Workshop-+2024

--- a/news/new_demos_scandem.rst
+++ b/news/new_demos_scandem.rst
@@ -11,7 +11,7 @@ The new demos are:
 
 * `Getting started with HyperSpy <https://nbviewer.org/github/hyperspy/hyperspy-demos/blob/main/1_Getting_Started.ipynb>`_
 * `HyperSpy fitting tutorial <https://nbviewer.org/github/hyperspy/hyperspy-demos/blob/main/Fitting_tutorial.ipynb>`_
-* `EELS analysis tutorial <https://nbviewer.org/github/hyperspy/hyperspy-demos/blob/main/electron_microscopy/EELS/EELS_analysis.ipynb>`_
+* `EELS analysis tutorial <https://nbviewer.org/github/hyperspy/exspy-demos/blob/main/EELS/EELS_analysis.ipynb>`_
 
 The demos are
 in the form of IPython notebooks and contain examples of usage. They can be


### PR DESCRIPTION
- Add `upcoming` tags to display upcoming events in the landing page, instead of relying on the most 3 recent,
- Add link to teaching materials of diamond workshop.